### PR TITLE
add roiconvert to the project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ YUV to RGB conversion. Combine Resize/Padding/Conversion/Normalization into a si
     - **Normalization**
 
 ## roi_conversion(CUDA Conversion)
-ROI to RGB conversion. Combine Resize/Padding/Conversion/Normalization into a single kernel function.
+ROIs to continuous tensor conversion. Combine Resize/Padding/Conversion/Normalization into a single kernel function.
 - **Most of the time, it can be bit-aligned with OpenCV.**
     - It will give an exact result when the scaling factor is a rational number.
     - Better performance is usually achieved when the stride can divide by 4.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,33 @@ YUV to RGB conversion. Combine Resize/Padding/Conversion/Normalization into a si
     - **Conversion**
     - **Normalization**
 
+## roi_conversion(CUDA Conversion)
+ROI to RGB conversion. Combine Resize/Padding/Conversion/Normalization into a single kernel function.
+- **Most of the time, it can be bit-aligned with OpenCV.**
+    - It will give an exact result when the scaling factor is a rational number.
+    - Better performance is usually achieved when the stride can divide by 4.
+- Supported Input Format:
+    - **NV12BlockLinear**
+    - **NV12PitchLinear**
+    - **YUV422Packed_YUYV**
+- Supported Interpolation methods:
+    - **Nearest**
+    - **Bilinear**
+- Supported Output Data Type:
+    - **Uint8**
+    - **Float32**
+    - **Float16**
+- Supported Output Layout:
+    - **CHW_RGB/BGR**
+    - **HWC_RGB/BGR**
+    - **CHW16/32/4/RGB/BGR for DLA input**
+    - **Gray**
+- Supported Features:
+    - **Resize**
+    - **Padding**
+    - **Conversion**
+    - **Normalization**
+
 ## Thanks
 This project makes use of a number of awesome open source libraries, including:
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ YUV to RGB conversion. Combine Resize/Padding/Conversion/Normalization into a si
     - **Conversion**
     - **Normalization**
 
-## roi_conversion(CUDA Conversion)
-ROIs to continuous tensor conversion. Combine Resize/Padding/Conversion/Normalization into a single kernel function.
+## ROI Conversion (ROIs To Continuous Tensor Conversion)
+Combine Resize/Padding/Conversion/Normalization into a single kernel function.
 - **Most of the time, it can be bit-aligned with OpenCV.**
     - It will give an exact result when the scaling factor is a rational number.
     - Better performance is usually achieved when the stride can divide by 4.

--- a/libraries/roiconvert/.gitattributes
+++ b/libraries/roiconvert/.gitattributes
@@ -1,8 +1,8 @@
-data/1920x1080-i420.yuv filter=lfs diff=lfs merge=lfs -text
-data/1920x1080-nv12.yuv filter=lfs diff=lfs merge=lfs -text
-data/375x500.rgb filter=lfs diff=lfs merge=lfs -text
 data/375x500.rgba filter=lfs diff=lfs merge=lfs -text
 data/ILSVRC2012_val_00023535.JPEG filter=lfs diff=lfs merge=lfs -text
 data/nv12_1280x720.yuv filter=lfs diff=lfs merge=lfs -text
 data/nv12_3840x2160.yuv filter=lfs diff=lfs merge=lfs -text
 data/yuyv_3840x2160_yuyv422.yuv filter=lfs diff=lfs merge=lfs -text
+data/1920x1080-i420.yuv filter=lfs diff=lfs merge=lfs -text
+data/1920x1080-nv12.yuv filter=lfs diff=lfs merge=lfs -text
+data/375x500.rgb filter=lfs diff=lfs merge=lfs -text

--- a/libraries/roiconvert/.gitattributes
+++ b/libraries/roiconvert/.gitattributes
@@ -1,8 +1,8 @@
-*.yuv filter=lfs diff=lfs merge=lfs -text
 data/1920x1080-i420.yuv filter=lfs diff=lfs merge=lfs -text
 data/1920x1080-nv12.yuv filter=lfs diff=lfs merge=lfs -text
 data/375x500.rgb filter=lfs diff=lfs merge=lfs -text
 data/375x500.rgba filter=lfs diff=lfs merge=lfs -text
+data/ILSVRC2012_val_00023535.JPEG filter=lfs diff=lfs merge=lfs -text
 data/nv12_1280x720.yuv filter=lfs diff=lfs merge=lfs -text
 data/nv12_3840x2160.yuv filter=lfs diff=lfs merge=lfs -text
 data/yuyv_3840x2160_yuyv422.yuv filter=lfs diff=lfs merge=lfs -text

--- a/libraries/roiconvert/.gitattributes
+++ b/libraries/roiconvert/.gitattributes
@@ -1,0 +1,8 @@
+*.yuv filter=lfs diff=lfs merge=lfs -text
+data/1920x1080-i420.yuv filter=lfs diff=lfs merge=lfs -text
+data/1920x1080-nv12.yuv filter=lfs diff=lfs merge=lfs -text
+data/375x500.rgb filter=lfs diff=lfs merge=lfs -text
+data/375x500.rgba filter=lfs diff=lfs merge=lfs -text
+data/nv12_1280x720.yuv filter=lfs diff=lfs merge=lfs -text
+data/nv12_3840x2160.yuv filter=lfs diff=lfs merge=lfs -text
+data/yuyv_3840x2160_yuyv422.yuv filter=lfs diff=lfs merge=lfs -text

--- a/libraries/roiconvert/.gitignore
+++ b/libraries/roiconvert/.gitignore
@@ -1,0 +1,10 @@
+/objs
+/workspace/*.jpg
+/workspace/pro
+*.binary
+*.ignore
+/workspace/*.png
+yuvtorgb
+*.so
+*.png
+/outputs

--- a/libraries/roiconvert/Makefile
+++ b/libraries/roiconvert/Makefile
@@ -1,0 +1,62 @@
+CUDA_VER?=
+ifeq ($(CUDA_VER),)
+  $(error "CUDA_VER is not set")
+endif
+
+cc        := g++
+cuda_home := /usr/local/cuda-$(CUDA_VER)
+cuda_arch := -gencode=arch=compute_80,code=sm_80
+nvcc      := $(cuda_home)/bin/nvcc -ccbin=$(cc)
+
+include_paths := -Isrc                \
+    -I$(cuda_home)/include		  	  \
+	-Iroi_conversion				  \
+	-I../../dependencies/pybind11/include			      \
+	-I/opt/conda3/include/python3.11/ \
+	-I/usr/include/python3.8/ \
+	-I/usr/include/python3.10
+
+library_paths := -L$(cuda_home)/lib64 \
+	-L/usr/lib/x86_64-linux-gnu/ \
+	-L./ \
+	-L/opt/conda3/lib/
+	
+
+cpp_compile_flags := -std=c++17 -w -g -O3 -fPIC -fopenmp -pthread $(include_paths)
+cu_compile_flags  := -std=c++17 -w -g -O3 $(cuda_arch) -Xcompiler "$(cpp_compile_flags)" $(include_paths)
+link_flags        := -pthread -fopenmp -Wl,-rpath='$$ORIGIN' $(library_paths) -lcudart -lcuda -Wl,-rpath='$(cuda_home)/lib64'
+
+roiconv.so : objs/roi_conversion/roi_conversion.cu.o objs/src/python.cpp.o
+	@echo Link $@
+	@mkdir -p $(dir $@)
+	@$(cc) -shared $^ -o $@ $(link_flags)
+
+py : roiconv.so
+test : roiconv.so
+	@python unitests/test_nv12.py
+
+test_all : roiconv.so
+	@python unitests/test_all.py
+
+test_resize : roiconv.so
+	@python unitests/test_resize.py
+
+test_perf : roiconv.so
+	@python unitests/test_perf.py
+
+objs/%.cpp.o : ./%.cpp
+	@echo Compile CXX $<
+	@mkdir -p $(dir $@)
+	@$(cc) -c $< -o $@ $(cpp_compile_flags)
+
+objs/%.cu.o : ./%.cu
+	@echo Compile CUDA $<
+	@mkdir -p $(dir $@)
+	@$(nvcc) -c $< -o $@ $(cu_compile_flags)
+
+clean :
+	@rm -rf objs roiconv roiconv.so
+
+.PHONY : clean run roiconv py
+
+export PYTHONPATH=.

--- a/libraries/roiconvert/README.md
+++ b/libraries/roiconvert/README.md
@@ -1,0 +1,64 @@
+# ROI Conversion
+ROIs to continuous tensor conversion. This is a library for implementing conversions from any number of ROIs to a continuous output tensor.
+
+## 1. Supported Feature
+- Input can be NV12 Block Linear or NV12 Pitch Linear or YUV_YUYV Packed or I420 Separated or RGBA or RGB.
+- Output color format can be Gray/BGR/GRB.
+- Output network order can be Gray/HWC/CHW/CHW4/CHW16/CHW32.
+- Conversion formula R/G/B_output = (R/G/B - offset_R/G/B) * scale_R/G/B
+- Rescale interpolation support Nearest and Bilinear mode
+- Verifed to keep exactly the same output as OpenCV
+- Async API to run on specific CUDA stream
+- Command line:
+
+## 2. unitests
+### 2.1 build
+```bash
+$ export CUDA_VER=12.6
+$ make
+```
+
+### 2.1 test cases
+```bash
+$ mkdir outputs
+$ python3 unitests/test_nv12.py     #input nv12
+or
+$ python3 unitests/test_rgba.py     #input rgba
+or
+$ python3  unitests/test_all.py     #input all supported formats.
+```
+
+### 2.2 Performance
+
+```bash
+$ python3  unitests/test_perf.py
+```
+Performance Table
+|Device            |             Conditions                      |  time consuming(ms)  |
+| ---------------- | ------------------------------------------- | --------- |
+|RTX 6000 Ada      |                   --                        |   0.20998 |
+
+### 2.3 How to Verify the Accuracy
+Reszie the RGBA source to a specific size by roi_conversion and opencv respectively. Then compare the two results.
+```
+$ pip install numpy opencv-python
+$ python3 unitests/test_resize.py
+(500, 375, 3)
+Startup
+[roiconv::Task object]
+  x0=11, y0=31, x1=75, y1=95
+  input_width=375, input_height=500, input_stride=1500
+  input_planes=[0x7cfceae89600, 0, 0]
+  output_width=256, output_height=256, output=0x7cfcd3a00000
+  affine_matrix=[4, 0, 0, 0, 4, 0]
+  alpha=[1, 1, 1]
+  beta=[0, 0, 0]
+  fillcolor=128, 128, 128
+OK = True
+0.0 0.0 0.0
+```
+
+## 3. User Integration
+- Only need to include *roi_conversion/roi_conversion.cu* and *roi_conversion/roi_conversion.hpp* for integration.
+- Pure C-style interface has been provided.
+- To make the library: `nvcc -Xcompiler "-fPIC" -shared -O3 roi_conversion/roi_conversion.cu -o libroiconvert_kernel.so -lcudart`

--- a/libraries/roiconvert/README.md
+++ b/libraries/roiconvert/README.md
@@ -48,7 +48,7 @@ Performance Table
   </tr>
   <tr>
     <td>Output(RGB)</td>
-    <td>NHWC</td>
+    <td>NCHW</td>
   </tr>
   <tr>
     <td>Input-Output</td>

--- a/libraries/roiconvert/README.md
+++ b/libraries/roiconvert/README.md
@@ -14,11 +14,10 @@ ROIs to continuous tensor conversion. This is a library for implementing convers
 ## 2. unitests
 ### 2.1 build
 ```bash
-$ export CUDA_VER=12.6
-$ make
+$ export CUDA_VER=12.6 && make
 ```
 
-### 2.1 test cases
+### 2.2 test cases
 ```bash
 $ mkdir outputs
 $ python3 unitests/test_nv12.py     #input nv12
@@ -28,7 +27,7 @@ or
 $ python3  unitests/test_all.py     #input all supported formats.
 ```
 
-### 2.2 Performance
+### 2.3 Performance
 
 ```bash
 $ python3  unitests/test_perf.py
@@ -36,9 +35,9 @@ $ python3  unitests/test_perf.py
 Performance Table
 |Device            |             Conditions                      |  time consuming(ms)  |
 | ---------------- | ------------------------------------------- | --------- |
-|RTX 6000 Ada      |                   --                        |   0.20998 |
+|RTX 6000 Ada      |   cuda12.6                                  |   0.20998 |
 
-### 2.3 How to Verify the Accuracy
+### 2.4 How to Verify the Accuracy
 Reszie the RGBA source to a specific size by roi_conversion and opencv respectively. Then compare the two results.
 ```
 $ pip install numpy opencv-python

--- a/libraries/roiconvert/README.md
+++ b/libraries/roiconvert/README.md
@@ -10,7 +10,7 @@ ROIs to continuous tensor conversion. This is a library for implementing convers
 - Verifed to keep exactly the same output as OpenCV
 - Async API to run on specific CUDA stream
 
-## 2. unitests
+## 2. Unitests
 ### 2.1 Build
 ```bash
 $ export CUDA_VER=12.6 && make
@@ -19,11 +19,9 @@ $ export CUDA_VER=12.6 && make
 ### 2.2 Test Cases
 ```bash
 $ mkdir outputs
-$ python3 unitests/test_nv12.py     #input nv12
-or
-$ python3 unitests/test_rgba.py     #input rgba
-or
-$ python3  unitests/test_all.py     #input all supported formats.
+$ python3 unitests/test_nv12.py     #Input nv12
+$ python3 unitests/test_rgba.py     #Input rgba
+$ python3  unitests/test_all.py     #Input all supported formats.
 ```
 
 ### 2.3 Performance
@@ -32,9 +30,36 @@ $ python3  unitests/test_all.py     #input all supported formats.
 $ python3  unitests/test_perf.py
 ```
 Performance Table
-|Device            |             Conditions                      |  time consuming(ms)  |
-| ---------------- | ------------------------------------------- | --------- |
-|RTX 6000 Ada      |   cuda12.6                                  |   0.20998 |
+<table>
+<thead>
+  <tr>
+    <th>Input</th>
+    <th colspan="6">NV12 Block Linear</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>Foumal</td>
+    <td colspan="6">R/G/B_Output = (R/G/B - offset_R/G/B) * scale_R/G/B</td>
+  </tr>
+  <tr>
+    <td>Environment</td>
+    <td colspan="6">RTX 6000 Ada / CUDA12.6 / BATCHSIZE=16</td>
+  </tr>
+  <tr>
+    <td>Output(RGB)</td>
+    <td>NHWC</td>
+  </tr>
+  <tr>
+    <td>Input-Output</td>
+    <td>1920x1080-960x544</td>
+  </tr>
+  <tr>
+    <td>FP32/Nearest</td>
+    <td>0.20998ms</td>
+  </tr>
+</tbody>
+</table>
 
 ### 2.4 How to Verify the Accuracy
 Reszie the RGBA source to a specific size by roi_conversion and opencv respectively. Then compare the two results.

--- a/libraries/roiconvert/README.md
+++ b/libraries/roiconvert/README.md
@@ -11,12 +11,12 @@ ROIs to continuous tensor conversion. This is a library for implementing convers
 - Async API to run on specific CUDA stream
 
 ## 2. unitests
-### 2.1 build
+### 2.1 Build
 ```bash
 $ export CUDA_VER=12.6 && make
 ```
 
-### 2.2 test cases
+### 2.2 Test Cases
 ```bash
 $ mkdir outputs
 $ python3 unitests/test_nv12.py     #input nv12

--- a/libraries/roiconvert/README.md
+++ b/libraries/roiconvert/README.md
@@ -9,7 +9,6 @@ ROIs to continuous tensor conversion. This is a library for implementing convers
 - Rescale interpolation support Nearest and Bilinear mode
 - Verifed to keep exactly the same output as OpenCV
 - Async API to run on specific CUDA stream
-- Command line:
 
 ## 2. unitests
 ### 2.1 build

--- a/libraries/roiconvert/data/1920x1080-i420.yuv
+++ b/libraries/roiconvert/data/1920x1080-i420.yuv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b00a87afade3045b5944de6d506733647c34bac70030f96a848aaa603d8cf7d8
+size 3110400

--- a/libraries/roiconvert/data/1920x1080-nv12.yuv
+++ b/libraries/roiconvert/data/1920x1080-nv12.yuv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfd7a70776c917b9b80d51a427f83ef5338b62b54ecd966f4463a301507cf35b
+size 3110400

--- a/libraries/roiconvert/data/375x500.rgb
+++ b/libraries/roiconvert/data/375x500.rgb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0befa9e7b9c243a5be4fa9e4e24930f7a05cafd05290508e3ceabf88b4def65
+size 562500

--- a/libraries/roiconvert/data/375x500.rgba
+++ b/libraries/roiconvert/data/375x500.rgba
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d60dcdcdeb419f8832ff3e8b4a0594f3c1b9ede115c0ddd085f1b88b6ec55d9
+size 750000

--- a/libraries/roiconvert/data/ILSVRC2012_val_00023535.JPEG
+++ b/libraries/roiconvert/data/ILSVRC2012_val_00023535.JPEG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c855a4038b06f573ed097c4c5b64be9ec19ec73fc51b58637a54ffc35d476a30
+size 177163

--- a/libraries/roiconvert/data/nv12_1280x720.yuv
+++ b/libraries/roiconvert/data/nv12_1280x720.yuv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4317bb71a2dec7e0e1f51dd66aa13aff6d98945ad03c5d64409be6be34bd7fd
+size 1382400

--- a/libraries/roiconvert/data/nv12_3840x2160.yuv
+++ b/libraries/roiconvert/data/nv12_3840x2160.yuv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c9495fbcad4f48403efcf802688e02ee655a28f0d49534afb92915cb638c780
+size 12441600

--- a/libraries/roiconvert/data/yuyv_3840x2160_yuyv422.yuv
+++ b/libraries/roiconvert/data/yuyv_3840x2160_yuyv422.yuv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b80a75f2016f20a57745d0bae04d4a1a511a73e854b276a4ee0bfe18a8623b24
+size 16588800

--- a/libraries/roiconvert/roi_conversion/roi_conversion.cu
+++ b/libraries/roiconvert/roi_conversion/roi_conversion.cu
@@ -1,0 +1,756 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+ 
+#include <stdio.h>
+#include <vector>
+#include <mutex>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include "roi_conversion.hpp"
+
+#define checkRuntime(call)  check_runtime(call, #call, __LINE__, __FILE__)
+#define half2short(h)   (*(unsigned short*)&h)
+
+namespace roiconv{
+
+struct ProblemPerBlock{
+    int output_x0, output_x1, output_y0, output_y1;
+    unsigned int input_task_id;
+
+    ProblemPerBlock() = default;
+    ProblemPerBlock(int output_x0_, int output_y0_, int output_x1_, int output_y1_, unsigned int input_task_id_)
+        :output_x0(output_x0_), output_x1(output_x1_), output_y0(output_y0_), output_y1(output_y1_), input_task_id(input_task_id_){}
+};
+
+typedef unsigned char uint8_t;
+
+template<typename _T>struct AsUnion4{};
+template<>struct AsUnion4<uint8_t>{typedef uchar4  type;};
+template<>struct AsUnion4<float>  {typedef float4  type;};
+template<>struct AsUnion4<__half> {typedef ushort4 type;};
+template<>struct AsUnion4<int8_t> {typedef char4   type;};
+template<>struct AsUnion4<int32_t> {typedef int4   type;};
+template<>struct AsUnion4<uint32_t> {typedef uint4   type;};
+
+template<typename _T>struct AsUnion3{};
+template<>struct AsUnion3<uint8_t>{typedef uchar3  type;};
+template<>struct AsUnion3<float>  {typedef float3  type;};
+template<>struct AsUnion3<__half> {typedef ushort3 type;};
+template<>struct AsUnion3<int8_t> {typedef char3   type;};
+template<>struct AsUnion3<int32_t> {typedef int3   type;};
+template<>struct AsUnion3<uint32_t> {typedef uint3   type;};
+
+template<OutputDType _T>struct AsPODType{};
+template<>struct AsPODType<OutputDType::Uint8>   {typedef uint8_t type;};
+template<>struct AsPODType<OutputDType::Float32> {typedef float   type;};
+template<>struct AsPODType<OutputDType::Float16> {typedef __half  type;};
+// template<>struct AsPODType<OutputDType::Int8>    {typedef int8_t type;};
+// template<>struct AsPODType<OutputDType::Int32>   {typedef int32_t type;};
+// template<>struct AsPODType<OutputDType::Uint32>  {typedef uint32_t type;};
+
+enum class Parallel : unsigned int{
+    None        = 0,
+    SinglePixel = 1,
+    FourPixel   = 2
+};
+
+static __device__ __forceinline__ uchar3 make3(uint8_t v0, uint8_t v1, uint8_t v2){return make_uchar3(v0, v1, v2);}
+// static __device__ __forceinline__ char3 make3(int8_t v0, int8_t v1, int8_t v2){return make_char3(v0, v1, v2);}
+static __device__ __forceinline__ float3 make3(float v0, float v1, float v2){return make_float3(v0, v1, v2);}
+static __device__ __forceinline__ ushort3 make3(__half v0, __half v1, __half v2){return make_ushort3(half2short(v0), half2short(v1), half2short(v2)); }
+// static __device__ __forceinline__ int3 make3(int v0, int v1, int v2){return make_int3(v0, v1, v2); }
+// static __device__ __forceinline__ uint3 make3(uint32_t v0, uint32_t v1, uint32_t v2){return make_uint3(v0, v1, v2); }
+
+#define INTER_RESIZE_COEF_BITS 11
+#define INTER_RESIZE_COEF_SCALE (1 << INTER_RESIZE_COEF_BITS)
+#define CAST_BITS (INTER_RESIZE_COEF_BITS << 1)
+
+template<typename _T>
+static __forceinline__ __device__ _T limit(_T value, _T low, _T high){
+    return value < low ? low : (value > high ? high : value);
+}
+
+template<typename _T>
+static __device__ __forceinline__ uint8_t u8cast(_T value){
+    return value < 0 ? 0 : (value >= 255 ? 255 : uint8_t(value));
+}
+
+template<typename _T>
+static __device__ __forceinline__ int8_t s8cast(_T value){
+    return value <= -128 ? -128 : (value >= 127 ? 127 : int8_t(value));
+}
+
+template<typename _T>struct Saturate{};
+template<>struct Saturate<int8_t>   {__device__ __forceinline__ static int8_t cast(float x){return s8cast(x);}};
+template<>struct Saturate<uint8_t>  {__device__ __forceinline__ static uint8_t cast(float x){return u8cast(x);}};
+template<>struct Saturate<float>    {__device__ __forceinline__ static float cast(float x){return x;}};
+template<>struct Saturate<__half>   {__device__ __forceinline__ static __half cast(float x){return __half(x);}};
+template<>struct Saturate<int32_t>   {__device__ __forceinline__ static int32_t cast(float x){return int32_t(x);}};
+template<>struct Saturate<uint32_t>   {__device__ __forceinline__ static uint32_t cast(float x){return uint32_t(x);}};
+
+static bool __inline__ check_runtime(cudaError_t e, const char* call, int line, const char *file){
+    if (e != cudaSuccess) {
+        fprintf(stderr, "CUDA Runtime error %s # %s, code = %s [ %d ] in file %s:%d\n", call, cudaGetErrorString(e), cudaGetErrorName(e), e, file, line);
+        return false;
+    }
+    return true;
+}
+
+template<typename T, OutputFormat _Layout>
+struct DataWriter{};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////// NHWC RGB
+template<typename T>
+struct DataWriter<T, OutputFormat::HWC_RGB>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        *(typename AsUnion3<T>::type*)(pdst + (y * width + x) * 3) = make3(r, g, b);
+    }
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////// NHWC BGR
+template<typename T>
+struct DataWriter<T, OutputFormat::HWC_BGR>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        *(typename AsUnion3<T>::type*)(pdst + (y * width + x) * 3) = make3(b, g, r);
+    }
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////// CHW RGB
+template<typename T>
+struct DataWriter<T, OutputFormat::CHW_RGB>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        *(pdst + ((0 * height + y) * width + x)) = r;
+        *(pdst + ((1 * height + y) * width + x)) = g;
+        *(pdst + ((2 * height + y) * width + x)) = b;
+    }
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////// CHW BGR
+template<typename T>
+struct DataWriter<T, OutputFormat::CHW_BGR>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        *(pdst + ((0 * height + y) * width + x)) = b;
+        *(pdst + ((1 * height + y) * width + x)) = g;
+        *(pdst + ((2 * height + y) * width + x)) = r;
+    }
+};
+
+template<typename T>
+struct DataWriter<T, OutputFormat::Gray>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        *(pdst + y * width + x) = r;
+    }
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////// CHWx RGB
+template<typename T, int SC>
+struct CHWxRGBWriter{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+
+        // for CHW(S): tensor.view(N, C/S, S, H, W).transpose(0, 1, 3, 4, 2)
+        *(typename AsUnion3<T>::type*)(pdst + (y * width + x) * SC) = make3(r, g, b);
+    }
+};
+
+template<typename T, int SC>
+struct CHWxBGRWriter{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+
+        // for CHW(S): tensor.view(N, C/S, S, H, W).transpose(0, 1, 3, 4, 2)
+        *(typename AsUnion3<T>::type*)(pdst + (y * width + x) * SC) = make3(b, g, r);
+    }
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////// CHWx RGB/BGR
+template<typename T>
+struct DataWriter<T, OutputFormat::CHW16_RGB>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        CHWxRGBWriter<T, 16>::call(pdst, r, g, b, x, y, width, height);
+    }
+};
+
+template<typename T>
+struct DataWriter<T, OutputFormat::CHW16_BGR>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        CHWxBGRWriter<T, 16>::call(pdst, r, g, b, x, y, width, height);
+    }
+};
+
+template<typename T>
+struct DataWriter<T, OutputFormat::CHW32_RGB>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        CHWxRGBWriter<T, 32>::call(pdst, r, g, b, x, y, width, height);
+    }
+};
+
+template<typename T>
+struct DataWriter<T, OutputFormat::CHW32_BGR>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        CHWxBGRWriter<T, 32>::call(pdst, r, g, b, x, y, width, height);
+    }
+};
+
+template<typename T>
+struct DataWriter<T, OutputFormat::CHW4_RGB>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        CHWxRGBWriter<T, 4>::call(pdst, r, g, b, x, y, width, height);
+    }
+};
+
+template<typename T>
+struct DataWriter<T, OutputFormat::CHW4_BGR>{
+    static __device__ __forceinline__ void call(T* pdst, T r, T g, T b, int x, int y, int width, int height){
+        CHWxBGRWriter<T, 4>::call(pdst, r, g, b, x, y, width, height);
+    }
+};
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+static __device__ unsigned int __forceinline__ round_down2(unsigned int num){
+    return num & (~1);
+}
+
+template<typename T, OutputFormat output_format>
+struct Normalizer{
+    static __device__ void __forceinline__ call(
+        uint8_t ir, uint8_t ig, uint8_t ib, T& r, T& g, T& b,
+        float alphas[3], float betas[3]
+    ){
+        r = Saturate<T>::cast(ir * alphas[0] + betas[0]);
+        g = Saturate<T>::cast(ig * alphas[1] + betas[1]);
+        b = Saturate<T>::cast(ib * alphas[2] + betas[2]);
+    }
+};
+
+template<typename T>
+struct Normalizer<T, OutputFormat::Gray>{
+    static __device__ void __forceinline__ call(
+        uint8_t ir, uint8_t ig, uint8_t ib, T& r, T& g, T& b,
+        float alphas[3], float betas[3]
+    ){
+        // 0.299 ∙ Red + 0.587 ∙ Green + 0.114 ∙ Blue
+        float gray = ir * 0.299f + ig * 0.587f + ib * 0.114f;
+        r = Saturate<T>::cast(gray * alphas[0] + betas[0]);
+    }
+};
+
+static __device__ void __forceinline__ yuv2rgb(
+    int y, int u, int v, uint8_t& r, uint8_t& g, uint8_t& b
+){
+    int iyval = 1220542 * max(0, y - 16);
+    r = u8cast((iyval + 1673527*(v - 128)                      + (1 << 19)) >> 20);
+    g = u8cast((iyval - 852492*(v - 128) - 409993*(u - 128)    + (1 << 19)) >> 20);
+    b = u8cast((iyval                      + 2116026*(u - 128) + (1 << 19)) >> 20);
+}
+
+template<InputFormat format>
+static __device__ void __forceinline__ load_pixel(
+    const void* const planes[3],
+    int x, int y, int down_x, int width, int stride, uint8_t& r, uint8_t& g, uint8_t& b
+);
+
+template<>
+__device__ void __forceinline__ load_pixel<InputFormat::RGBA>(
+    const void* const planes[3],
+    int x, int y, int down_x, int width, int stride, uint8_t& r, uint8_t& g, uint8_t& b
+){
+    uchar4 data = *(const uchar4*)((const char*)planes[0] + y * stride + x * 4);
+    r = data.x;
+    g = data.y;
+    b = data.z;
+}
+
+template<>
+__device__ void __forceinline__ load_pixel<InputFormat::RGB>(
+    const void* const planes[3],
+    int x, int y, int down_x, int width, int stride, uint8_t& r, uint8_t& g, uint8_t& b
+){
+    uchar3 data = *(const uchar3*)((const char*)planes[0] + y * stride + x * 3);
+    r = data.x;
+    g = data.y;
+    b = data.z;
+}
+
+template<>
+__device__ void __forceinline__ load_pixel<InputFormat::YUVI420Separated>(
+    const void* const planes[3],
+    int x, int y, int down_x, int width, int stride, uint8_t& r, uint8_t& g, uint8_t& b
+){
+    uint8_t yv = *((const unsigned char*)planes[0] + y * width + x);
+    uint8_t uv = *((const unsigned char*)planes[1] + (y / 2) * (width / 2) + (x / 2));
+    uint8_t vv = *((const unsigned char*)planes[2] + (y / 2) * (width / 2) + (x / 2));
+    yuv2rgb(yv, uv, vv, r, g, b);
+}
+
+// BL sample pixel implmentation
+template<>
+__device__ void __forceinline__ load_pixel<InputFormat::NV12BlockLinear>(
+    const void* const planes[3],
+    int x, int y, int down_x, int width, int stride, uint8_t& r, uint8_t& g, uint8_t& b
+){
+    uint8_t yv = tex2D<uint8_t>((cudaTextureObject_t)planes[0],   x,          y    );
+    // If chroma bytes per pixel = 1.
+    // uint8_t uv = tex2D<uint8_t>((cudaTextureObject_t)chroma, down_x + 0, y / 2);
+    // uint8_t vv = tex2D<uint8_t>((cudaTextureObject_t)chroma, down_x + 1, y / 2);
+    // yuv2rgb(yv, uv, vv, r, g, b);
+
+    // If chroma bytes per pixel = 2.
+    uchar2 uv  = tex2D<uchar2>((cudaTextureObject_t)planes[1], x / 2, y / 2);
+    yuv2rgb(yv, uv.x, uv.y, r, g, b);
+}
+
+// PL sample pixel implmentation
+template<>
+__device__ void __forceinline__ load_pixel<InputFormat::NV12PitchLinear>(
+    const void* const planes[3],
+    int x, int y, int down_x, int width, int stride, uint8_t& r, uint8_t& g, uint8_t& b
+){
+    uint8_t yv = *((const unsigned char*)planes[0] + y * stride + x);
+    uint8_t uv = *((const unsigned char*)planes[1] + (y / 2) * stride + down_x + 0);
+    uint8_t vv = *((const unsigned char*)planes[1] + (y / 2) * stride + down_x + 1);
+    yuv2rgb(yv, uv, vv, r, g, b);
+}
+
+//     Y U Y V Y U Y V      Y Y Y Y Y Y      Y Y Y Y Y Y      Y Y Y Y Y Y      Y Y Y Y Y Y
+//     Y U Y V Y U Y V      Y Y Y Y Y Y      Y Y Y Y Y Y      Y Y Y Y Y Y      Y Y Y Y Y Y
+//     Y U Y V Y U Y V      Y Y Y Y Y Y      Y Y Y Y Y Y      Y Y Y Y Y Y      Y Y Y Y Y Y
+//     Y U Y V Y U Y V      Y Y Y Y Y Y      Y Y Y Y Y Y      Y Y Y Y Y Y      Y Y Y Y Y Y
+//     Y U Y V Y U Y V      U U U U U U      V V V V V V      U V U V U V      V U V U V U
+//     Y U Y V Y U Y V      V V V V V V      U U U U U U      U V U V U V      V U V U V U
+//        - YUYV -           - I420 -          - YV12 -         - NV12 -         - NV21 -
+
+// YUV422Packed_YUYV sample pixel implmentation
+template<>
+__device__ void __forceinline__ load_pixel<InputFormat::YUV422Packed_YUYV>(
+    const void* const planes[3],
+    int x, int y, int down_x, int width, int stride, uint8_t& r, uint8_t& g, uint8_t& b
+){
+    // 0, 1, 2, 3, 4, 5, 6, 7
+    // 0, 0, 2, 2, 4, 4, 6, 6
+    // Y, U, Y, V, Y, U, Y, V
+    // 0,    1,    2,    3
+    uchar4 yuv = *(uchar4*)((const uint8_t*)planes[0] + y * stride + (x / 2) * 4);
+    if(x == down_x){
+        yuv2rgb(yuv.x, yuv.y, yuv.w, r, g, b);
+    }else{
+        yuv2rgb(yuv.z, yuv.y, yuv.w, r, g, b);
+    }
+}
+
+template<InputFormat input_format, Interpolation interp>
+struct LoadPixel{};
+
+// BL sample pixel implmentation
+template<InputFormat format>
+struct LoadPixel<format, Interpolation::Nearest>{
+    static __device__ void __forceinline__ call(
+        float x, float y, 
+        uint8_t& r, uint8_t& g, uint8_t& b, const Task& task
+    ){
+        // In some cases, the floating point precision will lead to miscalculation of the value, 
+        // making the result not exactly match with opencv, 
+        // so here you need to add eps as precision compensation
+        //
+        // A special case is when the input is 3840 and the output is 446, x = 223:
+        // const int SCrc_x_double = 223.0  * (3840.0  / 446.0);            // -> 1920
+        // const int SCrc_x_float  = 223.0f * (3840.0f / 446.0f);           // -> 1919
+        // const int SCrc_x_float  = 223.0f * (3840.0f / 446.0f) + 1e-5;    // -> 1920
+        //
+        // !!! If you want to use the double for sx/sy, you'll get a 2x speed drop
+        const float eps = 1e-5;
+        int ix = static_cast<int>(x + eps);
+        int iy = static_cast<int>(y + eps);
+        if(ix >= task.x0 && ix < task.x1 && iy >= task.y0 && iy < task.y1){
+            load_pixel<format>(task.input_planes, ix, iy, round_down2(ix), task.input_width, task.input_stride, r, g, b);
+        }else{
+            r = task.fillcolor[0]; g = task.fillcolor[1]; b = task.fillcolor[2];
+        }
+    }
+};
+
+template<InputFormat format>
+struct LoadPixel<format, Interpolation::Bilinear>{
+    static __device__ void __forceinline__ call(
+        float x, float y, 
+        uint8_t& r, uint8_t& g, uint8_t& b, const Task& task
+    ){
+        uint8_t rs[4], gs[4], bs[4];
+        int x_low  = floorf(x);
+        int y_low  = floorf(y);
+        int x_high = x_low + 1;
+        int y_high = y_low + 1;
+
+        int ly = rint((y - y_low) * INTER_RESIZE_COEF_SCALE);
+        int lx = rint((x - x_low) * INTER_RESIZE_COEF_SCALE);
+        int hy = INTER_RESIZE_COEF_SCALE - ly;
+        int hx = INTER_RESIZE_COEF_SCALE - lx;
+
+        load_pixel<format>(task.input_planes, x_low,  y_low,  round_down2(x_low),  task.input_width, task.input_stride, rs[0], gs[0], bs[0]);
+        if(x_high >= task.x0 && x_high < task.x1)
+            load_pixel<format>(task.input_planes, x_high, y_low,  round_down2(x_high), task.input_width, task.input_stride, rs[1], gs[1], bs[1]);
+
+        if(y_high >= task.y0 && y_high < task.y1)
+            load_pixel<format>(task.input_planes, x_low,  y_high, round_down2(x_low),  task.input_width, task.input_stride, rs[2], gs[2], bs[2]);
+
+        if(x_high >= task.x0 && x_high < task.x1 && y_high >= task.y0 && y_high < task.y1)
+            load_pixel<format>(task.input_planes, x_high, y_high, round_down2(x_high), task.input_width, task.input_stride, rs[3], gs[3], bs[3]);
+
+        r = ( ((hy * ((hx * rs[0] + lx * rs[1]) >> 4)) >> 16) + ((ly * ((hx * rs[2] + lx * rs[3]) >> 4)) >> 16) + 2 )>>2;
+        g = ( ((hy * ((hx * gs[0] + lx * gs[1]) >> 4)) >> 16) + ((ly * ((hx * gs[2] + lx * gs[3]) >> 4)) >> 16) + 2 )>>2;
+        b = ( ((hy * ((hx * bs[0] + lx * bs[1]) >> 4)) >> 16) + ((ly * ((hx * bs[2] + lx * bs[3]) >> 4)) >> 16) + 2 )>>2;
+    }
+};
+
+template<InputFormat input_format, typename output_dtype, OutputFormat output_format, Interpolation interp>
+static __global__ void convert_roi_kernel(Task* tasks, const int num_task, ProblemPerBlock* problems, const int num_problem){
+
+    #pragma unroll
+    for(int jk = 0; jk < 4; ++jk){
+        int iproblem = blockIdx.x * 4 + jk;
+        if(iproblem >= num_problem) continue;
+        ProblemPerBlock problem = problems[iproblem];
+
+        int x = threadIdx.x + problem.output_x0;
+        int y = threadIdx.y + problem.output_y0;
+        if(x >= problem.output_x1 || y >= problem.output_y1) continue;
+        
+        Task task = tasks[problem.input_task_id];
+        float fx = x + 0.5f;
+        float fy = y + 0.5f;
+        float ifx = fx * task.affine_matrix[0] + fy * task.affine_matrix[1] + task.affine_matrix[2] + task.x0 - 0.5f;
+        float ify = fx * task.affine_matrix[3] + fy * task.affine_matrix[4] + task.affine_matrix[5] + task.y0 - 0.5f;
+
+        uint8_t ir = task.fillcolor[0], ig = task.fillcolor[1], ib = task.fillcolor[2];
+        if(ifx >= task.x0 - 0.5f && ifx < task.x1 + 0.5f && ify >= task.y0 - 0.5f && ify < task.y1 + 0.5f){
+            ifx = max(float(task.x0), min(task.x1 - 1.0f, ifx));
+            ify = max(float(task.y0), min(task.y1 - 1.0f, ify));
+            LoadPixel<input_format, interp>::call(ifx, ify, ir, ig, ib, task);
+        }
+
+        output_dtype r, g, b;
+        Normalizer<output_dtype, output_format>::call(ir, ig, ib, r, g, b, task.alpha, task.beta);
+        DataWriter<output_dtype, output_format>::call(
+            (output_dtype*)task.output, r, g, b, x, y, task.output_width, task.output_height
+        );
+    }
+}
+
+template<InputFormat input_format, OutputDType out_dtype, OutputFormat layout, Interpolation interp>
+static bool batched_convert_roi_impl(Task* tasks, const int num_task, ProblemPerBlock* problems, const int num_problem, cudaStream_t stream){
+    using output_dtype = typename AsPODType<out_dtype>::type;
+
+    // HxW per block
+    dim3 dim_block(32, 32);
+    dim3 dim_grid((num_problem + 3) / 4);
+    convert_roi_kernel<input_format, output_dtype, layout, interp> <<<dim_grid, dim_block, 0, stream>>>(
+        tasks, num_task, problems, num_problem
+    );
+    return checkRuntime(cudaPeekAtLastError());
+}
+
+typedef bool(*batched_convert_roi_impl_function)(Task* tasks, const int num_task, ProblemPerBlock* problems, const int num_problem, cudaStream_t stream);
+
+// If you want to modify this part of the code, 
+// please note that the order of the enumerated types must match the integer values of this type 
+// (note: that the order starts from 1)
+
+#define DefineInputFormat(...)                                                    \
+    batched_convert_roi_impl<InputFormat::NV12BlockLinear, __VA_ARGS__>,   \
+    batched_convert_roi_impl<InputFormat::NV12PitchLinear, __VA_ARGS__>,   \
+    batched_convert_roi_impl<InputFormat::YUV422Packed_YUYV, __VA_ARGS__>, \
+    batched_convert_roi_impl<InputFormat::YUVI420Separated, __VA_ARGS__>,  \
+    batched_convert_roi_impl<InputFormat::RGBA, __VA_ARGS__>,              \
+    batched_convert_roi_impl<InputFormat::RGB, __VA_ARGS__>,
+
+#define DefineDType(...)                                               \
+    DefineInputFormat(OutputDType::Uint8, __VA_ARGS__)                    \
+    DefineInputFormat(OutputDType::Float32, __VA_ARGS__)                  \
+    DefineInputFormat(OutputDType::Float16, __VA_ARGS__)                  
+    // DefineInputFormat(OutputDType::Int8, __VA_ARGS__)                     \
+    // DefineInputFormat(OutputDType::Int32, __VA_ARGS__)                    \
+    // DefineInputFormat(OutputDType::Uint32, __VA_ARGS__)
+
+#define DefineLayout(...)                                            \
+    DefineDType(OutputFormat::CHW_RGB, __VA_ARGS__)                  \
+    DefineDType(OutputFormat::CHW_BGR, __VA_ARGS__)                  \
+    DefineDType(OutputFormat::HWC_RGB, __VA_ARGS__)                  \
+    DefineDType(OutputFormat::HWC_BGR, __VA_ARGS__)                  \
+    DefineDType(OutputFormat::CHW16_RGB, __VA_ARGS__)                \
+    DefineDType(OutputFormat::CHW16_BGR, __VA_ARGS__)                \
+    DefineDType(OutputFormat::CHW32_RGB, __VA_ARGS__)                \
+    DefineDType(OutputFormat::CHW32_BGR, __VA_ARGS__)                \
+    DefineDType(OutputFormat::CHW4_RGB, __VA_ARGS__)                 \
+    DefineDType(OutputFormat::CHW4_BGR, __VA_ARGS__)                 \
+    DefineDType(OutputFormat::Gray, __VA_ARGS__)
+
+#define DefineInterp                                            \
+    DefineLayout(Interpolation::Nearest)                        \
+    DefineLayout(Interpolation::Bilinear)              
+
+#define DefineAllFunction   DefineInterp
+
+template<typename T>struct EnumCount{};
+template<> struct EnumCount<InputFormat>{static const unsigned int value = 6;};
+template<> struct EnumCount<OutputDType>{static const unsigned int value = 3;};
+template<> struct EnumCount<OutputFormat>{static const unsigned int value = 11;};
+template<> struct EnumCount<Interpolation>{static const unsigned int value = 2;};
+
+static const batched_convert_roi_impl_function func_list[] = {
+    DefineAllFunction
+    nullptr
+};
+
+static bool batch_convert_rois(Task* tasks, const unsigned int num_task, ProblemPerBlock* problems, const int num_problem, InputFormat input_format, OutputDType output_dtype, OutputFormat output_format, Interpolation interpolation, cudaStream_t stream){
+    int iformat = (int)input_format - 1;
+    int odtype  = (int)output_dtype    - 1;
+    int olayout = (int)output_format   - 1;
+    int iinterp = (int)interpolation - 1;
+    int index = ((iinterp * EnumCount<OutputFormat>::value + olayout) * EnumCount<OutputDType>::value + odtype) * EnumCount<InputFormat>::value + iformat;
+    if(
+        iformat < 0 || iformat >= EnumCount<InputFormat>::value ||
+        odtype < 0  || odtype >= EnumCount<OutputDType>::value ||
+        olayout < 0 || olayout >= EnumCount<OutputFormat>::value ||
+        iinterp < 0 || iinterp >= EnumCount<Interpolation>::value ||
+        index < 0   || index >= sizeof(func_list) / sizeof(func_list[0]) - 1
+    ){
+        fprintf(stderr, "Unsupported configure %d.\n", index);
+        return false;
+    }
+    batched_convert_roi_impl_function func = func_list[index];
+    return func(tasks, num_task, problems, num_problem, stream);
+}
+
+template<typename T>
+class PinnedMemoryAlloctor{
+public:
+    typedef T value_type;
+ 
+    PinnedMemoryAlloctor() = default;
+
+    template<class U>
+    constexpr PinnedMemoryAlloctor(const PinnedMemoryAlloctor<U>&) noexcept {}
+ 
+    [[nodiscard]] T* allocate(std::size_t n){
+        if (n > std::numeric_limits<std::size_t>::max() / sizeof(T))
+            throw std::bad_array_new_length();
+
+        T* p = nullptr;
+        if (checkRuntime(cudaMallocHost(&p, sizeof(T) * n))){
+            return p;
+        }
+        throw std::bad_alloc();
+        return nullptr;
+    }
+ 
+    void deallocate(T* p, std::size_t n) noexcept{
+        checkRuntime(cudaFreeHost(p));
+    }
+};
+
+static void inverse_affine_matrix(const float src[6], float dst[6]){
+    float a = src[0], b = src[1], c = src[2];
+    float d = src[3], e = src[4], f = src[5];
+    float r = a * e - b * d;
+    if(r != 0) r = 1.0f / r;
+    dst[0] = e * r; dst[1] = -b * r; dst[2] = (b * f - c * e) * r;
+    dst[3] = -d * r; dst[4] = a * r; dst[5] = -(a * f - c * d) * r;
+}
+
+void Task::resize_affine(){
+    float roi_width  = x1 - x0;
+    float roi_height = y1 - y0;
+    memset(affine_matrix, 0, sizeof(affine_matrix));
+    affine_matrix[0] = output_width / roi_width;
+    affine_matrix[4] = output_height / roi_height;
+}
+
+void Task::center_resize_affine(){
+    float roi_width  = x1 - x0;
+    float roi_height = y1 - y0;
+    float sx = output_width / roi_width;
+    float sy = output_height / roi_height;
+    float min_scale = std::min(sx, sy);
+    memset(affine_matrix, 0, sizeof(affine_matrix));
+    affine_matrix[0] = min_scale;
+    affine_matrix[2] = (output_width - roi_width * min_scale) * 0.5f;
+    affine_matrix[4] = min_scale;
+    affine_matrix[5] = (output_height - roi_height * min_scale) * 0.5f;
+}
+
+class ROIConversionImpl : public ROIConversion{
+public:
+    ROIConversionImpl(){
+        tasks_.reserve(256);
+        tasks_cached_.reserve(256);
+        problems_.reserve(4096 * 8);
+        problems_cached_.reserve(4096 * 8);
+    }
+
+    virtual ~ROIConversionImpl(){
+        if(gpu_tasks_ != nullptr){
+            checkRuntime(cudaFree(gpu_tasks_));
+            gpu_tasks_ = nullptr;
+            gpu_tasks_capacity_ = 0;
+        }
+
+        if(gpu_problems_ != nullptr){
+            checkRuntime(cudaFree(gpu_problems_));
+            gpu_problems_ = nullptr;
+            gpu_problems_capacity_ = 0;
+        }
+        tasks_cached_.clear();
+        tasks_.clear();
+
+        problems_cached_.clear();
+        problems_.clear();
+    }
+
+    virtual void add(const Task& task) override{
+        tasks_.emplace_back(task);
+    }
+
+    void convert_to_problems(){
+        const int x_block_size = 32;
+        const int y_block_size = 32;
+        unsigned int total_problem_size_added = 0;
+        for(unsigned int i = 0; i < (unsigned int)tasks_.size(); ++i){
+            auto& task = tasks_[i];
+            inverse_affine_matrix(task.affine_matrix, task.affine_matrix);
+
+            int xmin = std::min(task.x0, task.x1);
+            int xmax = std::max(task.x0, task.x1);
+            int ymin = std::min(task.y0, task.y1);
+            int ymax = std::max(task.y0, task.y1);
+            task.x0 = std::max(0, std::min(xmin, task.input_width - 1));
+            task.y0 = std::max(0, std::min(ymin, task.input_height - 1));
+            task.x1 = std::max(0, std::min(xmax, task.input_width));
+            task.y1 = std::max(0, std::min(ymax, task.input_height));
+
+            const int ngrid_x = (task.output_width + x_block_size - 1) / x_block_size;
+            const int ngrid_y = (task.output_height + y_block_size - 1) / y_block_size;
+            total_problem_size_added += ngrid_x * ngrid_y;
+        }
+        problems_.resize(total_problem_size_added);
+
+        unsigned int index_problem = 0;
+        for(unsigned int i = 0; i < (unsigned int)tasks_.size(); ++i){
+            auto& task = tasks_[i];
+            const int ngrid_x = (task.output_width + x_block_size - 1) / x_block_size;
+            const int ngrid_y = (task.output_height + y_block_size - 1) / y_block_size;
+
+            for(int iy = 0; iy < ngrid_y; ++iy){
+                for(int ix = 0; ix < ngrid_x; ++ix){
+                    const int x0 = ix * x_block_size;
+                    const int y0 = iy * y_block_size;
+                    problems_[index_problem++] = ProblemPerBlock(
+                        x0, y0,
+                        std::min(x0 + x_block_size, task.output_width),
+                        std::min(y0 + y_block_size, task.output_height),
+                        i
+                    );
+                }
+            }
+        }
+    }
+
+    bool data_preparation(void* stream, bool clear){
+        if(tasks_.empty()) return true;
+
+        this->convert_to_problems();
+        if(problems_.empty()){
+            tasks_.clear();
+            return false;
+        }
+
+        {
+            if(gpu_tasks_capacity_ < tasks_.size()){
+                if(!checkRuntime(cudaFree(gpu_tasks_))) return false;
+
+                gpu_tasks_capacity_ = std::max(size_t((double)tasks_.size() * 1.2), size_t(256));
+                if(!checkRuntime(cudaMalloc(&gpu_tasks_, gpu_tasks_capacity_ * sizeof(Task)))) return false;
+            }
+
+            if(gpu_problems_capacity_ < problems_.size()){
+                if(!checkRuntime(cudaFree(gpu_problems_))) return false;
+
+                gpu_problems_capacity_ = std::max(size_t((double)problems_.size() * 1.2), size_t(4096));
+                if(!checkRuntime(cudaMalloc(&gpu_problems_, gpu_problems_capacity_ * sizeof(ProblemPerBlock)))) return false;
+            }
+            
+            tasks_cached_.resize(tasks_.size());
+            memcpy(tasks_cached_.data(), tasks_.data(), sizeof(Task) * tasks_.size());
+            
+            problems_cached_.resize(problems_.size());
+            memcpy(problems_cached_.data(), problems_.data(), sizeof(ProblemPerBlock) * problems_.size());
+
+            if(clear){
+                tasks_.clear();
+                problems_.clear();
+            }
+        };
+
+        if(!checkRuntime(cudaMemcpyAsync(gpu_tasks_, tasks_cached_.data(), sizeof(Task) * tasks_cached_.size(), cudaMemcpyHostToDevice, static_cast<cudaStream_t>(stream)))){
+            return false;
+        }
+        return checkRuntime(cudaMemcpyAsync(gpu_problems_, problems_cached_.data(), sizeof(ProblemPerBlock) * problems_cached_.size(), cudaMemcpyHostToDevice, static_cast<cudaStream_t>(stream)));
+    }
+
+    virtual bool run(InputFormat input_format, OutputDType output_dtype, OutputFormat output_format, Interpolation interpolation, void* stream, bool sync, bool clear) override{
+        if(!this->data_preparation(stream, clear)) return false;
+        
+        bool ok = batch_convert_rois(
+            gpu_tasks_, (unsigned int)tasks_cached_.size(), 
+            gpu_problems_, (unsigned int)problems_cached_.size(),
+            input_format, output_dtype, output_format, interpolation, 
+            static_cast<cudaStream_t>(stream)
+        );
+        if(!ok) return false;
+
+        if(sync){
+            ok = checkRuntime(cudaStreamSynchronize(static_cast<cudaStream_t>(stream)));
+        }
+        return ok;
+    }
+    
+private:
+    std::vector<Task, PinnedMemoryAlloctor<Task>> tasks_cached_;
+    std::vector<Task> tasks_;
+    std::vector<ProblemPerBlock, PinnedMemoryAlloctor<ProblemPerBlock>> problems_cached_;
+    std::vector<ProblemPerBlock> problems_;
+    Task* gpu_tasks_ = nullptr;
+    size_t gpu_tasks_capacity_ = 0;
+    ProblemPerBlock* gpu_problems_ = nullptr;
+    size_t gpu_problems_capacity_ = 0;
+};
+
+std::shared_ptr<ROIConversion> create(){
+    std::shared_ptr<ROIConversionImpl> output(new ROIConversionImpl());
+    return output;
+}
+
+}; // namespace roiconv

--- a/libraries/roiconvert/roi_conversion/roi_conversion.hpp
+++ b/libraries/roiconvert/roi_conversion/roi_conversion.hpp
@@ -1,0 +1,81 @@
+#ifndef __ROI_CONVERSION_HPP__
+#define __ROI_CONVERSION_HPP__
+
+#include <memory>
+
+namespace roiconv{
+
+enum class InputFormat : unsigned int{
+    NoneEnum          = 0,
+    NV12BlockLinear   = 1,   // Y, UV   stride = width
+    NV12PitchLinear   = 2,   // Y, UV   stride = width
+    YUV422Packed_YUYV = 3,   // YUV     stride = width * 2
+    YUVI420Separated  = 4,   // Y, U, V stride = width
+    RGBA              = 5,   // stride = width * 4
+    RGB               = 6    // stride = width * 3
+};
+
+enum class Interpolation : unsigned int{
+    NoneEnum    = 0,
+    Nearest     = 1,
+    Bilinear    = 2
+};
+
+enum class OutputDType : unsigned int{
+    NoneEnum    = 0,
+    Uint8       = 1,
+    Float32     = 2,
+    Float16     = 3
+    // Int8        = 4,
+    // Int32       = 5,
+    // Uint32      = 6
+};
+
+enum class OutputFormat : unsigned int{
+    NoneEnum   = 0,
+    CHW_RGB   = 1,
+    CHW_BGR   = 2,
+    HWC_RGB   = 3,
+    HWC_BGR   = 4,
+    CHW16_RGB = 5,  // c = (c + 15) / 16 * 16 if c % 16 != 0 else c
+    CHW16_BGR = 6,
+    CHW32_RGB = 7,  // c = (c + 31) / 32 * 32 if c % 32 != 0 else c
+    CHW32_BGR = 8,
+    CHW4_RGB  = 9,  // c = (c + 3) / 4 * 4 if c % 4 != 0 else c
+    CHW4_BGR  = 10,
+    Gray      = 11
+};
+
+struct Task{
+    int x0, y0, x1, y1;  // source coordinates in pixels.
+    const void *input_planes[3];
+    int input_width, input_height;
+    int input_stride;
+
+    void* output;
+    int output_width, output_height;
+
+    float affine_matrix[6];
+    float alpha[3], beta[3];
+    unsigned char fillcolor[3];
+
+    void resize_affine();
+    void center_resize_affine();
+};
+
+class ROIConversion{
+public:
+    virtual void add(const Task& task) = 0;
+    virtual bool run(InputFormat input_format, OutputDType output_dtype, OutputFormat output_format, Interpolation interpolation, void* stream, bool sync=false, bool clear=true) = 0;
+};
+
+// image = load_image(width, height)
+// roi = image(x0, y0, x1, y1)
+// roi = affine(roi, matrix, fill=fillcolor, dst_size=(width, height), interp=interpolation)
+// roi = roi * alpha + beta
+// store(roi, dest, format=dest_format, dtype=dest_dtype)
+std::shared_ptr<ROIConversion> create();
+
+}; // namespace roiconv
+
+#endif // __ROI_CONVERSION_HPP__

--- a/libraries/roiconvert/src/python.cpp
+++ b/libraries/roiconvert/src/python.cpp
@@ -1,0 +1,441 @@
+#include "roi_conversion.hpp"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <sstream>
+#include <cuda_runtime.h>
+
+namespace py = pybind11;
+
+#define checkRuntime(call)  check_runtime(call, #call, __LINE__, __FILE__)
+
+static bool __inline__ check_runtime(cudaError_t e, const char* call, int line, const char *file){
+    if (e != cudaSuccess) {
+        fprintf(stderr, "CUDA Runtime error %s # %s, code = %s [ %d ] in file %s:%d\n", call, cudaGetErrorString(e), cudaGetErrorName(e), e, file, line);
+        return false;
+    }
+    return true;
+}
+
+static std::vector<uint8_t> load_file(const char* file, size_t expect_size){
+    FILE* f = fopen(file, "rb");
+    if(f == nullptr){
+        printf("Failed to open file: %s\n", file);
+        return {};
+    } 
+
+    fseek(f, 0, SEEK_END);
+    size_t fsize = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if(fsize != expect_size){
+        printf("Mismatched file size: %d, expected is %d\n", fsize, expect_size);
+        fclose(f);
+        return {};
+    }
+
+    std::vector<uint8_t> host_data(fsize);
+    if(fread(host_data.data(), 1, fsize, f) != fsize){
+        printf("Failed to read %s bytes from file: %s\n", fsize, file);
+        fclose(f);
+        return {};
+    }
+    fclose(f);
+    return host_data;
+}
+
+struct NV12BlockLinear{
+    cudaTextureObject_t luma = 0;     // y
+    cudaTextureObject_t chroma = 0;     // uv
+    cudaArray_t luma_array;
+    cudaArray_t chroma_array;
+    unsigned int width = 0, height = 0;
+    unsigned int stride = 0;
+};
+
+void free_nv12blocklinear(NV12BlockLinear* ptr){
+    if(ptr == nullptr) return;
+
+    checkRuntime(cudaDestroyTextureObject(ptr->luma));
+    checkRuntime(cudaDestroyTextureObject(ptr->chroma));
+    checkRuntime(cudaFreeArray(ptr->luma_array));
+    checkRuntime(cudaFreeArray(ptr->chroma_array));
+    delete ptr;
+}
+
+std::shared_ptr<NV12BlockLinear> load_nv12blocklinear(const char* nv12pl_file, int width, int height){
+
+    auto host_data = load_file(nv12pl_file, width * height * 3 / 2);
+    if(host_data.empty()) return nullptr;
+
+    NV12BlockLinear* output = new NV12BlockLinear();
+    output->width  = width;
+    output->height = height;
+    output->stride = width;
+    cudaChannelFormatDesc YplaneDesc = cudaCreateChannelDesc(8, 0, 0, 0, cudaChannelFormatKindUnsigned);
+    checkRuntime(cudaMallocArray(&output->luma_array,   &YplaneDesc, width, height, 0));
+    checkRuntime(cudaMemcpy2DToArray(output->luma_array, 0, 0, host_data.data(), width, width, height, cudaMemcpyHostToDevice));
+
+    // One pixel of the uv channel contains 2 bytes
+    cudaChannelFormatDesc UVplaneDesc = cudaCreateChannelDesc(8, 8, 0, 0, cudaChannelFormatKindUnsigned);
+    checkRuntime(cudaMallocArray(&output->chroma_array, &UVplaneDesc, width / 2, height / 2, 0));
+    checkRuntime(cudaMemcpy2DToArray(output->chroma_array, 0, 0, host_data.data() + width * height, width, width, height / 2, cudaMemcpyHostToDevice));
+
+    cudaResourceDesc luma_desc = {};
+    luma_desc.resType         = cudaResourceTypeArray;
+    luma_desc.res.array.array = output->luma_array;
+
+    cudaTextureDesc texture_desc = {};
+    texture_desc.filterMode = cudaFilterModePoint;
+    texture_desc.readMode   = cudaReadModeElementType;
+    checkRuntime(cudaCreateTextureObject(&output->luma, &luma_desc, &texture_desc, NULL));
+
+    cudaResourceDesc chroma_desc = {};
+    chroma_desc.resType         = cudaResourceTypeArray;
+    chroma_desc.res.array.array = output->chroma_array;
+    checkRuntime(cudaCreateTextureObject(&output->chroma, &chroma_desc, &texture_desc, NULL));
+    return std::shared_ptr<NV12BlockLinear>(output, free_nv12blocklinear);
+}
+
+struct NV12PitchLinear{
+    void* luma = nullptr;     // y
+    void* chroma = nullptr;     // uv
+    unsigned int width = 0, height = 0;
+    unsigned int stride = 0;
+};
+
+void free_nv12pitchlinear(NV12PitchLinear* ptr){
+    if(ptr == nullptr) return;
+    checkRuntime(cudaFree(ptr->luma));
+    checkRuntime(cudaFree(ptr->chroma));
+    delete ptr;
+}
+
+std::shared_ptr<NV12PitchLinear> load_nv12pitchlinear(const char* nv12pl_file, int width, int height){
+
+    auto host_data = load_file(nv12pl_file, width * height * 3 / 2);
+    if(host_data.empty()) return nullptr;
+
+    NV12PitchLinear* output = new NV12PitchLinear();
+    output->width  = width;
+    output->height = height;
+    output->stride = width;
+    checkRuntime(cudaMalloc(&output->luma, width * height));
+    checkRuntime(cudaMalloc(&output->chroma, width * height / 2));
+    checkRuntime(cudaMemcpy(output->luma, host_data.data(), width * height, cudaMemcpyHostToDevice));
+    checkRuntime(cudaMemcpy(output->chroma, host_data.data() + width * height, width * height / 2, cudaMemcpyHostToDevice));
+    return std::shared_ptr<NV12PitchLinear>(output, free_nv12pitchlinear);
+}
+
+struct YUV422Packed_YUYV{
+    void* data = nullptr;     // y
+    unsigned int width = 0, height = 0;
+    unsigned int stride = 0;
+};
+
+void free_yuv422packed_yuyv(YUV422Packed_YUYV* ptr){
+    if(ptr == nullptr) return;
+    checkRuntime(cudaFree(ptr->data));
+    delete ptr;
+}
+
+std::shared_ptr<YUV422Packed_YUYV> load_yuv422packed_yuyv(const char* nv12pl_file, int width, int height){
+
+    auto host_data = load_file(nv12pl_file, width * height * 2);
+    if(host_data.empty()) return nullptr;
+
+    YUV422Packed_YUYV* output = new YUV422Packed_YUYV();
+    output->width  = width;
+    output->height = height;
+    output->stride = width * 2;
+    checkRuntime(cudaMalloc(&output->data, width * height * 2));
+    checkRuntime(cudaMemcpy(output->data, host_data.data(), width * height * 2, cudaMemcpyHostToDevice));
+    return std::shared_ptr<YUV422Packed_YUYV>(output, free_yuv422packed_yuyv);
+}
+
+struct YUVI420Separated{
+    void* y = nullptr;     // y
+    void* u = nullptr;     // u
+    void* v = nullptr;     // v
+    unsigned int width = 0, height = 0;
+    unsigned int stride = 0;
+};
+
+void free_yuvi420separated(YUVI420Separated* ptr){
+    if(ptr == nullptr) return;
+    checkRuntime(cudaFree(ptr->y));
+    checkRuntime(cudaFree(ptr->u));
+    checkRuntime(cudaFree(ptr->v));
+    delete ptr;
+}
+
+std::shared_ptr<YUVI420Separated> load_yuvi420separated(const char* nv12pl_file, int width, int height){
+
+    auto host_data = load_file(nv12pl_file, width * height * 3 / 2);
+    if(host_data.empty()) return nullptr;
+
+    YUVI420Separated* output = new YUVI420Separated();
+    output->width  = width;
+    output->height = height;
+    output->stride = width;
+    checkRuntime(cudaMalloc(&output->y, width * height));
+    checkRuntime(cudaMalloc(&output->u, width * height / 4));
+    checkRuntime(cudaMalloc(&output->v, width * height / 4));
+    checkRuntime(cudaMemcpy(output->y, host_data.data(), width * height, cudaMemcpyHostToDevice));
+    checkRuntime(cudaMemcpy(output->u, host_data.data() + width * height, width * height / 4, cudaMemcpyHostToDevice));
+    checkRuntime(cudaMemcpy(output->v, host_data.data() + width * height + width * height / 4, width * height / 4, cudaMemcpyHostToDevice));
+    return std::shared_ptr<YUVI420Separated>(output, free_yuvi420separated);
+}
+
+struct RGBImage{
+    void* data = nullptr; 
+    unsigned int width = 0, height = 0;
+    unsigned int stride = 0;
+};
+
+void free_rgbimage(RGBImage* ptr){
+    if(ptr == nullptr) return;
+    checkRuntime(cudaFree(ptr->data));
+    delete ptr;
+}
+
+std::shared_ptr<RGBImage> load_rgbimage(const char* file, int width, int height){
+
+    auto host_data = load_file(file, width * height * 3);
+    if(host_data.empty()) return nullptr;
+ 
+    RGBImage* output = new RGBImage();
+    output->width  = width;
+    output->height = height;
+    output->stride = width * 3;
+    checkRuntime(cudaMalloc(&output->data, width * height * 3));
+    checkRuntime(cudaMemcpy(output->data, host_data.data(), width * height * 3, cudaMemcpyHostToDevice));
+    return std::shared_ptr<RGBImage>(output, free_rgbimage);
+}
+
+struct RGBAImage{
+    void* data = nullptr; 
+    unsigned int width = 0, height = 0;
+    unsigned int stride = 0;
+};
+
+void free_rgbaimage(RGBAImage* ptr){
+    if(ptr == nullptr) return;
+    checkRuntime(cudaFree(ptr->data));
+    delete ptr;
+}
+
+std::shared_ptr<RGBAImage> load_rgbaimage(const char* file, int width, int height){
+
+    auto host_data = load_file(file, width * height * 4);
+    if(host_data.empty()) return nullptr;
+ 
+    RGBAImage* output = new RGBAImage();
+    output->width  = width;
+    output->height = height;
+    output->stride = width * 4;
+    checkRuntime(cudaMalloc(&output->data, width * height * 4));
+    checkRuntime(cudaMemcpy(output->data, host_data.data(), width * height * 4, cudaMemcpyHostToDevice));
+    return std::shared_ptr<RGBAImage>(output, free_rgbaimage);
+}
+
+PYBIND11_MODULE(roiconv, m){
+
+     py::class_<NV12BlockLinear, std::shared_ptr<NV12BlockLinear>>(m, "load_nv12blocklinear")
+        .def(py::init([](const char* nv12pl_file, int width, int height){
+            return load_nv12blocklinear(nv12pl_file, width, height);
+        }))
+        .def_property_readonly("width", [](NV12BlockLinear& self){return self.width;})
+        .def_property_readonly("height", [](NV12BlockLinear& self){return self.height;})
+        .def_property_readonly("stride", [](NV12BlockLinear& self){return self.stride;})
+        .def_property_readonly("luma", [](NV12BlockLinear& self){return (uint64_t)self.luma;})
+        .def_property_readonly("chroma", [](NV12BlockLinear& self){return (uint64_t)self.chroma;})
+        .def("__repr__", [](NV12BlockLinear& self){
+            std::stringstream repr;
+            repr << "[NV12BlockLinear object]\n";
+            repr << "  width=" << self.width << ", stride=" << self.stride << ", height=" << self.height << ", ";
+            repr << "  luma=" << self.luma << ", chroma=" << self.chroma;
+            return repr.str();
+        });
+     
+     py::class_<NV12PitchLinear, std::shared_ptr<NV12PitchLinear>>(m, "load_nv12pitchlinear")
+        .def(py::init([](const char* nv12pl_file, int width, int height){
+            return load_nv12pitchlinear(nv12pl_file, width, height);
+        }))
+        .def_property_readonly("width", [](NV12PitchLinear& self){return self.width;})
+        .def_property_readonly("height", [](NV12PitchLinear& self){return self.height;})
+        .def_property_readonly("stride", [](NV12PitchLinear& self){return self.stride;})
+        .def_property_readonly("luma", [](NV12PitchLinear& self){return (uint64_t)self.luma;})
+        .def_property_readonly("chroma", [](NV12PitchLinear& self){return (uint64_t)self.chroma;})
+        .def("__repr__", [](NV12PitchLinear& self){
+            std::stringstream repr;
+            repr << "[NV12PitchLinear object]\n";
+            repr << "  width=" << self.width << ", stride=" << self.stride << ", height=" << self.height << ", ";
+            repr << "  luma=" << self.luma << ", chroma=" << self.chroma;
+            return repr.str();
+        });
+     
+     py::class_<YUV422Packed_YUYV, std::shared_ptr<YUV422Packed_YUYV>>(m, "load_yuv422packed_yuyv")
+        .def(py::init([](const char* nv12pl_file, int width, int height){
+            return load_yuv422packed_yuyv(nv12pl_file, width, height);
+        }))
+        .def_property_readonly("width", [](YUV422Packed_YUYV& self){return self.width;})
+        .def_property_readonly("height", [](YUV422Packed_YUYV& self){return self.height;})
+        .def_property_readonly("stride", [](YUV422Packed_YUYV& self){return self.stride;})
+        .def_property_readonly("data", [](YUV422Packed_YUYV& self){return (uint64_t)self.data;})
+        .def("__repr__", [](YUV422Packed_YUYV& self){
+            std::stringstream repr;
+            repr << "[YUV422Packed_YUYV object]\n";
+            repr << "  width=" << self.width << ", stride=" << self.stride << ", height=" << self.height << ", ";
+            repr << "  data=" << self.data;
+            return repr.str();
+        });
+
+     py::class_<YUVI420Separated, std::shared_ptr<YUVI420Separated>>(m, "load_yuvi420separated")
+        .def(py::init([](const char* nv12pl_file, int width, int height){
+            return load_yuvi420separated(nv12pl_file, width, height);
+        }))
+        .def_property_readonly("width", [](YUVI420Separated& self){return self.width;})
+        .def_property_readonly("height", [](YUVI420Separated& self){return self.height;})
+        .def_property_readonly("stride", [](YUVI420Separated& self){return self.stride;})
+        .def_property_readonly("y", [](YUVI420Separated& self){return (uint64_t)self.y;})
+        .def_property_readonly("u", [](YUVI420Separated& self){return (uint64_t)self.u;})
+        .def_property_readonly("v", [](YUVI420Separated& self){return (uint64_t)self.v;})
+        .def("__repr__", [](YUVI420Separated& self){
+            std::stringstream repr;
+            repr << "[YUVI420Separated object]\n";
+            repr << "  width=" << self.width << ", stride=" << self.stride << ", height=" << self.height << ", ";
+            repr << "  y=" << self.y << ",  u=" << self.u << ",  v=" << self.v;
+            return repr.str();
+        });
+
+     py::class_<RGBAImage, std::shared_ptr<RGBAImage>>(m, "load_rgbaimage")
+        .def(py::init([](const char* nv12pl_file, int width, int height){
+            return load_rgbaimage(nv12pl_file, width, height);
+        }))
+        .def_property_readonly("width", [](RGBAImage& self){return self.width;})
+        .def_property_readonly("height", [](RGBAImage& self){return self.height;})
+        .def_property_readonly("stride", [](RGBAImage& self){return self.stride;})
+        .def_property_readonly("data", [](RGBAImage& self){return (uint64_t)self.data;})
+        .def("__repr__", [](RGBAImage& self){
+            std::stringstream repr;
+            repr << "[RGBAImage object]\n";
+            repr << "  width=" << self.width << ", stride=" << self.stride << ", height=" << self.height << ", ";
+            repr << "  data=" << self.data;
+            return repr.str();
+        });
+
+     py::class_<RGBImage, std::shared_ptr<RGBImage>>(m, "load_rgbimage")
+        .def(py::init([](const char* nv12pl_file, int width, int height){
+            return load_rgbimage(nv12pl_file, width, height);
+        }))
+        .def_property_readonly("width", [](RGBImage& self){return self.width;})
+        .def_property_readonly("height", [](RGBImage& self){return self.height;})
+        .def_property_readonly("stride", [](RGBImage& self){return self.stride;})
+        .def_property_readonly("data", [](RGBImage& self){return (uint64_t)self.data;})
+        .def("__repr__", [](RGBImage& self){
+            std::stringstream repr;
+            repr << "[RGBImage object]\n";
+            repr << "  width=" << self.width << ", stride=" << self.stride << ", height=" << self.height << ", ";
+            repr << "  data=" << self.data;
+            return repr.str();
+        });
+
+    py::enum_<roiconv::InputFormat>(m, "InputFormat")
+        .value("NV12BlockLinear", roiconv::InputFormat::NV12BlockLinear)
+        .value("NV12PitchLinear", roiconv::InputFormat::NV12PitchLinear)
+        .value("RGB", roiconv::InputFormat::RGB)
+        .value("RGBA", roiconv::InputFormat::RGBA)
+        .value("YUV422Packed_YUYV", roiconv::InputFormat::YUV422Packed_YUYV)
+        .value("YUVI420Separated", roiconv::InputFormat::YUVI420Separated);
+
+    py::enum_<roiconv::OutputDType>(m, "OutputDType")
+        .value("Float16", roiconv::OutputDType::Float16)
+        .value("Float32", roiconv::OutputDType::Float32)
+        .value("Uint8", roiconv::OutputDType::Uint8);
+        // .value("Int32", roiconv::OutputDType::Int32)
+        // .value("Int8", roiconv::OutputDType::Int8)
+        // .value("Uint32", roiconv::OutputDType::Uint32)
+
+    py::enum_<roiconv::OutputFormat>(m, "OutputFormat")
+        .value("CHW16_BGR", roiconv::OutputFormat::CHW16_BGR)
+        .value("CHW16_RGB", roiconv::OutputFormat::CHW16_RGB)
+        .value("CHW32_BGR", roiconv::OutputFormat::CHW32_BGR)
+        .value("CHW32_RGB", roiconv::OutputFormat::CHW32_RGB)
+        .value("CHW4_BGR", roiconv::OutputFormat::CHW4_BGR)
+        .value("CHW4_RGB", roiconv::OutputFormat::CHW4_RGB)
+        .value("CHW_BGR", roiconv::OutputFormat::CHW_BGR)
+        .value("CHW_RGB", roiconv::OutputFormat::CHW_RGB)
+        .value("Gray", roiconv::OutputFormat::Gray)
+        .value("HWC_BGR", roiconv::OutputFormat::HWC_BGR)
+        .value("HWC_RGB", roiconv::OutputFormat::HWC_RGB);
+
+    py::enum_<roiconv::Interpolation>(m, "Interpolation")
+        .value("Bilinear", roiconv::Interpolation::Bilinear)
+        .value("Nearest", roiconv::Interpolation::Nearest);
+
+    py::class_<roiconv::Task>(m, "Task")
+        .def(py::init([](int x0, int y0, int x1, int y1, int input_width, int input_stride, int input_height, std::vector<uint64_t> input_planes, int output_width, int output_height, uint64_t output_ptr, std::vector<float> affine_matrix, std::vector<float> alpha, std::vector<float> beta, std::vector<unsigned char> fillcolor){
+            roiconv::Task output;
+            output.x0 = x0;
+            output.y0 = y0;
+            output.x1 = x1;
+            output.y1 = y1;
+            output.input_width   = input_width;
+            output.input_stride  = input_stride;
+            output.input_height  = input_height;
+            output.output_width  = output_width;
+            output.output_height = output_height;
+            output.output        = (void*)output_ptr;
+            if(input_planes.size() != 3) throw py::value_error();
+            if(affine_matrix.size() != 6) throw py::value_error();
+            if(alpha.size() != 3) throw py::value_error();
+            if(beta.size() != 3) throw py::value_error();
+            if(fillcolor.size() != 3) throw py::value_error();
+            memcpy(output.input_planes, input_planes.data(), sizeof(output.input_planes));
+            memcpy(output.affine_matrix, affine_matrix.data(), sizeof(output.affine_matrix));
+            memcpy(output.alpha, alpha.data(), sizeof(output.alpha));
+            memcpy(output.beta, beta.data(), sizeof(output.beta));
+            memcpy(output.fillcolor, fillcolor.data(), sizeof(output.fillcolor));
+            return output;
+        }))
+        .def_property("x0", [](roiconv::Task& self){return self.x0;}, [](roiconv::Task& self, int new_value){self.x0 = new_value;})
+        .def_property("y0", [](roiconv::Task& self){return self.y0;}, [](roiconv::Task& self, int new_value){self.y0 = new_value;})
+        .def_property("x1", [](roiconv::Task& self){return self.x1;}, [](roiconv::Task& self, int new_value){self.x1 = new_value;})
+        .def_property("y1", [](roiconv::Task& self){return self.y1;}, [](roiconv::Task& self, int new_value){self.y1 = new_value;})
+        .def_property("input_planes", [](roiconv::Task& self){return std::vector<uint64_t>((uint64_t*)self.input_planes, (uint64_t*)self.input_planes + 3);}, [](roiconv::Task& self, const std::vector<uint64_t>& new_value){if(new_value.size() != 3) throw py::value_error(); memcpy(self.input_planes, new_value.data(), sizeof(self.input_planes));})
+        .def_property("input_width", [](roiconv::Task& self){return self.input_width;}, [](roiconv::Task& self, int new_value){self.input_width = new_value;})
+        .def_property("input_stride", [](roiconv::Task& self){return self.input_stride;}, [](roiconv::Task& self, int new_value){self.input_stride = new_value;})
+        .def_property("input_height", [](roiconv::Task& self){return self.input_height;}, [](roiconv::Task& self, int new_value){self.input_height = new_value;})
+        .def_property("output", [](roiconv::Task& self){return self.output;}, [](roiconv::Task& self, uint64_t new_value){self.output = (void*)new_value;})
+        .def_property("output_width", [](roiconv::Task& self){return self.output_width;}, [](roiconv::Task& self, int new_value){self.output_width = new_value;})
+        .def_property("output_height", [](roiconv::Task& self){return self.output_height;}, [](roiconv::Task& self, int new_value){self.output_height = new_value;})
+        .def_property("affine_matrix", [](roiconv::Task& self){return std::vector<float>(self.affine_matrix, self.affine_matrix + 6);}, [](roiconv::Task& self, const std::vector<float>& new_value){if(new_value.size() != 6) throw py::value_error(); memcpy(self.affine_matrix, new_value.data(), sizeof(self.affine_matrix));})
+        .def_property("alpha", [](roiconv::Task& self){return std::vector<float>(self.alpha, self.alpha + 3);}, [](roiconv::Task& self, const std::vector<float>& new_value){if(new_value.size() != 3) throw py::value_error(); memcpy(self.alpha, new_value.data(), sizeof(self.alpha));})
+        .def_property("beta", [](roiconv::Task& self){return std::vector<float>(self.beta, self.beta + 3);}, [](roiconv::Task& self, const std::vector<float>& new_value){if(new_value.size() != 3) throw py::value_error(); memcpy(self.beta, new_value.data(), sizeof(self.beta));})
+        .def_property("fillcolor", [](roiconv::Task& self){return std::vector<unsigned char>(self.fillcolor, self.fillcolor + 3);}, [](roiconv::Task& self, const std::vector<unsigned char>& new_value){if(new_value.size() != 3) throw py::value_error(); memcpy(self.fillcolor, new_value.data(), sizeof(self.fillcolor));})
+        .def("resize_affine", [](roiconv::Task& self){self.resize_affine();})
+        .def("center_resize_affine", [](roiconv::Task& self){self.center_resize_affine();})
+        .def("__repr__", [](roiconv::Task& self){
+            std::stringstream repr;
+            repr << "[roiconv::Task object]\n";
+            repr << "  x0=" << self.x0 << ", y0=" << self.y0 << ", x1=" << self.x1 << ", y1=" << self.y1 << "\n";
+            repr << "  input_width=" << self.input_width << ", input_height=" << self.input_height << ", input_stride=" << self.input_stride << "\n";
+            repr << "  input_planes=[" << self.input_planes[0] << ", " << self.input_planes[1] << ", " << self.input_planes[2] << "]\n";
+            repr << "  output_width=" << self.output_width << ", output_height=" << self.output_height << ", output=" << self.output << "\n";
+            repr << "  affine_matrix=[" << self.affine_matrix[0] << ", " << self.affine_matrix[1] << ", " << self.affine_matrix[2] << ", " << self.affine_matrix[3] << ", " << self.affine_matrix[4] << ", " << self.affine_matrix[5] << "]\n";
+            repr << "  alpha=[" << self.alpha[0] << ", " << self.alpha[1] << ", " << self.alpha[2] << "]\n";
+            repr << "  beta=[" << self.beta[0] << ", " << self.beta[1] << ", " << self.beta[2] << "]\n";
+            repr << "  fillcolor=" << (int)self.fillcolor[0] << ", " << (int)self.fillcolor[1] << ", " << (int)self.fillcolor[2];
+            return repr.str();
+        });
+
+    py::class_<roiconv::ROIConversion, std::shared_ptr<roiconv::ROIConversion>>(m, "ROIConversion")
+        .def(py::init([](){
+            return roiconv::create();
+        }))
+        .def("add", [](roiconv::ROIConversion& self, roiconv::Task task){
+            return self.add(task);
+        })
+        .def("run", [](roiconv::ROIConversion& self, roiconv::InputFormat input_format, roiconv::OutputDType output_dtype, roiconv::OutputFormat output_format, roiconv::Interpolation interpolation, uint64_t stream, bool sync, bool clear){
+            return self.run(input_format, output_dtype, output_format, interpolation, (void*)stream, sync, clear);
+        });
+}

--- a/libraries/roiconvert/unitests/test_all.py
+++ b/libraries/roiconvert/unitests/test_all.py
@@ -1,0 +1,178 @@
+import roiconv
+import torch
+import numpy as np
+import cv2
+
+input_formats = [
+    roiconv.InputFormat.NV12BlockLinear,
+    roiconv.InputFormat.NV12PitchLinear,
+    roiconv.InputFormat.YUV422Packed_YUYV,
+    roiconv.InputFormat.YUVI420Separated,
+    roiconv.InputFormat.RGBA,
+    roiconv.InputFormat.RGB
+]
+
+interpolations = [
+    roiconv.Interpolation.Bilinear,
+    roiconv.Interpolation.Nearest
+]
+
+output_dtypes = [
+    roiconv.OutputDType.Uint8,
+    roiconv.OutputDType.Float32,
+    roiconv.OutputDType.Float16,
+    # roiconv.OutputDType.Int8,
+    # roiconv.OutputDType.Int32,
+    # roiconv.OutputDType.Uint32
+]
+
+output_formats = [
+    roiconv.OutputFormat.CHW_RGB,
+    roiconv.OutputFormat.CHW_BGR,
+    roiconv.OutputFormat.HWC_RGB,
+    roiconv.OutputFormat.HWC_BGR,
+    roiconv.OutputFormat.CHW16_RGB,
+    roiconv.OutputFormat.CHW16_BGR,
+    roiconv.OutputFormat.CHW32_RGB,
+    roiconv.OutputFormat.CHW32_BGR,
+    roiconv.OutputFormat.CHW4_RGB,
+    roiconv.OutputFormat.CHW4_BGR,
+    roiconv.OutputFormat.Gray
+]
+
+def fill_by_input_format(task:roiconv.Task, input_format:roiconv.InputFormat, vars:dict):
+    if input_format == roiconv.InputFormat.NV12BlockLinear:
+        nv12 = roiconv.load_nv12blocklinear("data/nv12_3840x2160.yuv", 3840, 2160)
+        vars["input_format"] = {"nv12": nv12}
+        task.input_width = nv12.width
+        task.input_height = nv12.height
+        task.input_stride = nv12.stride
+        task.input_planes = [nv12.luma, nv12.chroma, 0]
+    elif input_format == roiconv.InputFormat.NV12PitchLinear:
+        nv12 = roiconv.load_nv12pitchlinear("data/nv12_3840x2160.yuv", 3840, 2160)
+        vars["input_format"] = {"nv12": nv12}
+        task.input_width = nv12.width
+        task.input_height = nv12.height
+        task.input_stride = nv12.stride
+        task.input_planes = [nv12.luma, nv12.chroma, 0]
+    elif input_format == roiconv.InputFormat.YUV422Packed_YUYV:
+        yuyv = roiconv.load_yuv422packed_yuyv("data/yuyv_3840x2160_yuyv422.yuv", 3840, 2160)
+        vars["input_format"] = {"yuyv": yuyv}
+        task.input_width = yuyv.width
+        task.input_height = yuyv.height
+        task.input_stride = yuyv.stride
+        task.input_planes = [yuyv.data, 0, 0]
+    elif input_format == roiconv.InputFormat.YUVI420Separated:
+        i420 = roiconv.load_yuvi420separated("data/1920x1080-i420.yuv", 1920, 1080)
+        vars["input_format"] = {"i420": i420}
+        task.input_width = i420.width
+        task.input_height = i420.height
+        task.input_stride = i420.stride
+        task.input_planes = [i420.y, i420.u, i420.v]
+    elif input_format == roiconv.InputFormat.RGB:
+        rgb = roiconv.load_rgbimage("data/375x500.rgb", 375, 500)
+        vars["input_format"] = {"rgb": rgb}
+        task.input_width = rgb.width
+        task.input_height = rgb.height
+        task.input_stride = rgb.stride
+        task.input_planes = [rgb.data, 0, 0]
+    elif input_format == roiconv.InputFormat.RGBA:
+        rgba = roiconv.load_rgbaimage("data/375x500.rgba", 375, 500)
+        vars["input_format"] = {"rgba": rgba}
+        task.input_width = rgba.width
+        task.input_height = rgba.height
+        task.input_stride = rgba.stride
+        task.input_planes = [rgba.data, 0, 0]
+    else:
+        raise NotImplementedError(f"Unknow input_format: {input_format}")
+
+def torch_dtype(output_dtype):
+    mapping = {
+        roiconv.OutputDType.Uint8   : torch.uint8,
+        roiconv.OutputDType.Float32 : torch.float32,
+        roiconv.OutputDType.Float16 : torch.float16,
+        # roiconv.OutputDType.Int8    : torch.int8,
+        # roiconv.OutputDType.Int32   : torch.int32,
+        # roiconv.OutputDType.Uint32  : torch.uint32
+    }
+    if output_dtype not in mapping:
+        raise NotImplementedError(f"Unknow output dtype: {output_dtype}")
+    return mapping[output_dtype]
+
+def make_output_tensor(output_dtype, output_format, width, height):
+    shapes = [height, width]
+    if output_format in [roiconv.OutputFormat.HWC_RGB, roiconv.OutputFormat.HWC_BGR]:
+        shapes = shapes + [3]
+    elif output_format in [roiconv.OutputFormat.CHW_RGB, roiconv.OutputFormat.CHW_BGR]:
+        shapes = [3] + shapes
+    elif output_format in [roiconv.OutputFormat.CHW16_RGB, roiconv.OutputFormat.CHW16_BGR]:
+        shapes = [16] + shapes
+    elif output_format in [roiconv.OutputFormat.CHW32_RGB, roiconv.OutputFormat.CHW32_BGR]:
+        shapes = [32] + shapes
+    elif output_format in [roiconv.OutputFormat.CHW4_RGB, roiconv.OutputFormat.CHW4_BGR]:
+        shapes = [4] + shapes
+    elif output_format == roiconv.OutputFormat.Gray:
+        shapes = shapes + [1]
+    else:
+        raise NotImplementedError(f"Unknow output format: {output_format}")
+
+    return (torch.rand(*shapes, device="cuda") * 255).to(torch_dtype(output_dtype))
+
+def store_output(i, input_format, output_dtype, output_format, interpolation, tensor):
+    if tensor.dtype != torch.int8:
+        tensor = tensor.clamp(0, 255)
+    tensor = tensor.cpu().data.numpy().astype(np.uint8)
+    if output_format in [roiconv.OutputFormat.HWC_RGB, roiconv.OutputFormat.HWC_BGR]:
+        image = tensor
+    elif output_format in [roiconv.OutputFormat.CHW_RGB, roiconv.OutputFormat.CHW_BGR]:
+        image = tensor.transpose(1, 2, 0)
+    elif output_format in [roiconv.OutputFormat.CHW16_RGB, roiconv.OutputFormat.CHW16_BGR]:
+        image = tensor.reshape(tensor.shape[1], tensor.shape[2], -1)[..., :3]
+    elif output_format in [roiconv.OutputFormat.CHW32_RGB, roiconv.OutputFormat.CHW32_BGR]:
+        image = tensor.reshape(tensor.shape[1], tensor.shape[2], -1)[..., :3]
+    elif output_format in [roiconv.OutputFormat.CHW4_RGB, roiconv.OutputFormat.CHW4_BGR]:
+        image = tensor.reshape(tensor.shape[1], tensor.shape[2], -1)[..., :3]
+    elif output_format == roiconv.OutputFormat.Gray:
+        image = tensor.squeeze(-1)
+
+    name = f"outputs/{i:03d}_{input_format.name}_{output_dtype.name}_{output_format.name}_{interpolation.name}.jpg"
+    print(name, image.shape, tensor.shape)
+    cv2.imwrite(name, image)
+
+convtor = roiconv.ROIConversion()
+task = roiconv.Task(
+    15, 31, 256, 256,
+    0, 0, 0,
+    [0, 0, 0], 
+    256, 256,
+    0,
+    [1, 0, 0, 0, 1, 0], 
+    [1, 1, 1], 
+    [0, 0, 0], 
+    [128, 128, 128]
+)
+
+vars = dict()
+i = 0
+for input_format in input_formats:
+    fill_by_input_format(task, input_format, vars)
+
+    for interpolation in [roiconv.Interpolation.Bilinear]:
+        for output_dtype in output_dtypes:
+            for output_format in output_formats:
+                output_tensor = make_output_tensor(output_dtype, output_format, 512, 512)
+                task.output_width = 512
+                task.output_height = 512
+                task.x0 = 0
+                task.y0 = 0
+                task.x1 = task.input_width
+                task.y1 = task.input_height
+                task.output = output_tensor.data_ptr()
+                task.center_resize_affine()
+                convtor.add(task)
+                print(f"Run: {input_format}, {interpolation}, {output_dtype}, {output_format}, output: {output_tensor.shape}, {output_tensor.dtype}, min: {output_tensor.cpu().data.numpy().min()}, max: {output_tensor.cpu().data.numpy().max()}")
+                assert convtor.run(input_format, output_dtype, output_format, interpolation, 0, True, True), f"Failed to run convertor"
+                i += 1
+                store_output(i, input_format, output_dtype, output_format, interpolation, output_tensor)
+
+print("Done.")

--- a/libraries/roiconvert/unitests/test_nv12.py
+++ b/libraries/roiconvert/unitests/test_nv12.py
@@ -1,0 +1,25 @@
+import roiconv
+import torch
+import cv2
+
+nv12 = roiconv.load_nv12blocklinear("data/nv12_3840x2160.yuv", 3840, 2160)
+output_tensor = torch.zeros(256, 256, 3).cuda()
+
+convtor = roiconv.ROIConversion()
+task = roiconv.Task(
+    0, 0, nv12.width, nv12.height,
+    nv12.width, nv12.stride, nv12.height,
+    [nv12.luma, nv12.chroma, 0], 
+    256, 256,
+    output_tensor.data_ptr(),
+    [1, 0, 0, 0, 1, 0], 
+    [1, 1, 1], 
+    [0, 0, 0], 
+    [128, 128, 128]
+)
+task.center_resize_affine()
+print(task)
+convtor.add(task)
+
+ok = convtor.run(roiconv.InputFormat.NV12BlockLinear, roiconv.OutputDType.Float32, roiconv.OutputFormat.HWC_BGR, roiconv.Interpolation.Nearest, 0, True, True)
+cv2.imwrite("output.png", output_tensor.to(torch.uint8).cpu().data.numpy())

--- a/libraries/roiconvert/unitests/test_perf.py
+++ b/libraries/roiconvert/unitests/test_perf.py
@@ -1,0 +1,37 @@
+import roiconv
+import torch
+import cv2
+
+images = []
+convtor = roiconv.ROIConversion()
+for i in range(16):
+    nv12 = roiconv.load_nv12blocklinear("data/1920x1080-nv12.yuv", 1920, 1080)
+    output_tensor = torch.zeros(3, 544, 960).cuda()
+    images.append([nv12, output_tensor])
+
+    task = roiconv.Task(
+        0, 0, nv12.width, nv12.height,
+        nv12.width, nv12.stride, nv12.height,
+        [nv12.luma, nv12.chroma, 0], 
+        960, 544,
+        output_tensor.data_ptr(),
+        [1, 0, 0, 0, 1, 0], 
+        [1, 1, 1], 
+        [0, 0, 0], 
+        [128, 128, 128]
+    )
+    task.resize_affine()
+    convtor.add(task)
+
+import time
+
+for i in range(100):
+    ok = convtor.run(roiconv.InputFormat.NV12BlockLinear, roiconv.OutputDType.Float32, roiconv.OutputFormat.CHW_RGB, roiconv.Interpolation.Nearest, 0, True, False)
+
+for i in range(100):
+    now = time.time()
+    ok = convtor.run(roiconv.InputFormat.NV12BlockLinear, roiconv.OutputDType.Float32, roiconv.OutputFormat.CHW_RGB, roiconv.Interpolation.Nearest, 0, True, False)
+    gap = time.time() - now
+    print(f"{gap * 1000:.3f} ms")
+
+cv2.imwrite("output.png", output_tensor.permute(1, 2, 0).to(torch.uint8).cpu().data.numpy())

--- a/libraries/roiconvert/unitests/test_resize.py
+++ b/libraries/roiconvert/unitests/test_resize.py
@@ -1,0 +1,41 @@
+import roiconv
+import cv2
+import torch
+import numpy as np
+
+roi = 11, 31, 11 + 64, 31 + 64
+image = cv2.imread("data/ILSVRC2012_val_00023535.JPEG")
+cv2.rectangle(image, (roi[0], roi[1]), (roi[2], roi[3]), (0, 255, 0), 2)
+# image = cv2.resize(image, dsize=(1920, 1080))
+torch_image = torch.from_numpy(image).cuda()
+torch_image = torch.cat([torch_image, torch.randn(torch_image.size(0), torch_image.size(1), 1, device="cuda").to(torch.uint8)], dim=-1)
+output_tensor = torch.zeros(256, 256, 3).cuda()
+print(image.shape)
+print(f"Startup")
+convtor = roiconv.ROIConversion()
+task = roiconv.Task(
+    *roi,
+    image.shape[1], image.shape[1] * 4, image.shape[0],
+    [torch_image.data_ptr(), 0, 0], 
+    256, 256,
+    output_tensor.data_ptr(),
+    [1, 0, 0, 0, 1, 0], 
+    [1, 1, 1], 
+    [0, 0, 0], 
+    [128, 128, 128]
+)
+task.resize_affine()
+print(task)
+convtor.add(task)
+
+ok = convtor.run(roiconv.InputFormat.RGBA, roiconv.OutputDType.Float32, roiconv.OutputFormat.HWC_RGB, roiconv.Interpolation.Bilinear, 0, True, True)
+print(f"OK = {ok}")
+
+output_image = output_tensor.to(torch.uint8).cpu().data.numpy()
+resize_image = cv2.resize(image[roi[1]:roi[3], roi[0]:roi[2]], dsize=(task.output_width, task.output_height))
+diff = np.abs(resize_image.astype(np.float32) - output_image.astype(np.float32))
+print(diff.mean(), diff.sum(), diff.max())
+cv2.imwrite("output.png", output_image)
+cv2.imwrite("diff.png", (diff * 100).clip(0, 255).astype(np.uint8))
+cv2.imwrite("image.jpg", image)
+cv2.imwrite("resize_image.jpg", resize_image)

--- a/libraries/roiconvert/unitests/test_rgba.py
+++ b/libraries/roiconvert/unitests/test_rgba.py
@@ -1,0 +1,36 @@
+import roiconv
+import cv2
+import torch
+
+roi = 100, 30, 200, 250
+image = cv2.imread("data/ILSVRC2012_val_00023535.JPEG")
+cv2.rectangle(image, (roi[0], roi[1]), (roi[2], roi[3]), (0, 255, 0), 2)
+# image = cv2.resize(image, dsize=(1920, 1080))
+torch_image = torch.from_numpy(image).cuda()
+torch_image = torch.cat([torch_image, torch.randn(torch_image.size(0), torch_image.size(1), 1, device="cuda").to(torch.uint8)], dim=-1)
+output_tensor = torch.zeros(544, 960, 3).cuda()
+print(image.shape)
+print(f"Startup")
+convtor = roiconv.ROIConversion()
+task = roiconv.Task(
+    *roi,
+    image.shape[1], image.shape[1] * 4, image.shape[0],
+    [torch_image.data_ptr(), 0, 0], 
+    960, 544,
+    output_tensor.data_ptr(),
+    [1, 0, 0, 0, 1, 0], 
+    [1, 1, 1], 
+    [0, 0, 0], 
+    [128, 128, 128]
+)
+task.center_resize_affine()
+print(task)
+convtor.add(task)
+
+ok = convtor.run(roiconv.InputFormat.RGBA, roiconv.OutputDType.Float32, roiconv.OutputFormat.HWC_RGB, roiconv.Interpolation.Nearest, 0, True, True)
+print(f"OK = {ok}")
+ok = convtor.run(roiconv.InputFormat.RGBA, roiconv.OutputDType.Float32, roiconv.OutputFormat.HWC_RGB, roiconv.Interpolation.Nearest, 0, True, True)
+print(f"OK = {ok}")
+
+cv2.imwrite("output.png", output_tensor.to(torch.uint8).cpu().data.numpy())
+cv2.imwrite("image.jpg", image)


### PR DESCRIPTION
ROIs to continuous tensor conversion. This is a library for implementing conversions from any number of ROIs to a continuous output tensor.
Supported Feature
Input can be NV12 Block Linear or NV12 Pitch Linear or YUV_YUYV Packed or I420 Separated or RGBA or RGB.
Output color format can be Gray/BGR/GRB.
Output network order can be Gray/HWC/CHW/CHW4/CHW16/CHW32.
Conversion formula R/G/B_output = (R/G/B - offset_R/G/B) * scale_R/G/B
Rescale interpolation support Nearest and Bilinear mode
Verifed to keep exactly the same output as OpenCV
Async API to run on specific CUDA stream