### PR TITLE
Harden CUDA-BEVFusion tensor file loading

### DIFF
--- a/CUDA-BEVFusion/src/common/tensor.cu
+++ b/CUDA-BEVFusion/src/common/tensor.cu
@@ -521,7 +521,14 @@ Tensor Tensor::load(const std::string& file, bool device) {
 
   int ndim = head[1];
   int dtypei = head[2];
-  int dims[16];
+  constexpr int max_ndim = 16;
+  int dims[max_ndim];
+
+  if (ndim < 1 || ndim > max_ndim) {
+    printf("This is invalid tensor file %s\n", file.c_str());
+    fclose(f);
+    return Tensor();
+  }
 
   if (fread(dims, 1, ndim * sizeof(int), f) == 0) {
     printf("This is invalid tensor file %s\n", file.c_str());


### PR DESCRIPTION
## Summary

`Tensor::load()` trusted the file-controlled `ndim` and copied
`ndim * sizeof(int)` bytes into a fixed `int dims[16]` buffer. An `ndim` of
17 therefore caused a stack-buffer overflow.

Validate that `ndim` is within the fixed buffer capacity before reading the
dimensions.

## Example

A file can start with `{0x33ff1101, 17, valid_dtype}` followed by 17
dimension integers. The original code then executes:

```cpp
int dims[16];
fread(dims, 1, ndim * sizeof(int), f);
```

With `ndim = 17`, this copies 68 bytes into a 64-byte stack buffer,
overwriting the next 4 bytes on the stack.

## Validation

- the original `ndim = 17` input is rejected
- valid tensor files continue to load
